### PR TITLE
Move js-module into android container in order not to install for other ...

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -16,16 +16,12 @@
         <engine name="cordova" version=">=3.0.0"/>
     </engines>
 
-    <js-module src="www/backgroundservice.js" name="BackgroundService">
-        <clobbers target="window.plugins.BackgroundServices" />
-    </js-module>
-    
-
-    
-       
     <!-- android -->
     <platform name="android">
-
+        <js-module src="www/backgroundservice.js" name="BackgroundService">
+            <clobbers target="window.plugins.BackgroundServices" />
+        </js-module>
+        
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="BackgroundServicePlugin">
                 <param name="android-package" value="com.red_folder.phonegap.plugin.backgroundservice.BackgroundServicePlugin"/>


### PR DESCRIPTION
If you don't place the <js-module> within a particular platform container element, it gets installed for _every_ platform.
